### PR TITLE
Fix regression in mm/hotplug, allows NVIDIA driver to work

### DIFF
--- a/mm/memory_hotplug.c
+++ b/mm/memory_hotplug.c
@@ -883,23 +883,6 @@ static int online_pages_range(unsigned long start_pfn, unsigned long nr_pages,
 	return 0;
 }
 
-#ifdef CONFIG_MOVABLE_NODE
-/*
- * When CONFIG_MOVABLE_NODE, we permit onlining of a node which doesn't have
- * normal memory.
- */
-static bool can_online_high_movable(int nid)
-{
-	return true;
-}
-#else /* CONFIG_MOVABLE_NODE */
-/* ensure every online node has NORMAL memory */
-static bool can_online_high_movable(int nid)
-{
-	return node_state(nid, N_NORMAL_MEMORY);
-}
-#endif /* CONFIG_MOVABLE_NODE */
-
 /* check which state of node_states will be changed when online memory */
 static void node_states_check_changes_online(unsigned long nr_pages,
 	struct zone *zone, struct memory_notify *arg)
@@ -1029,8 +1012,7 @@ int __ref online_pages(unsigned long pfn, unsigned long nr_pages, int online_typ
 	zone = page_zone(pfn_to_page(pfn));
 
 	if ((zone_idx(zone) > ZONE_NORMAL ||
-	    online_type == MMOP_ONLINE_MOVABLE) &&
-	    !can_online_high_movable(pfn_to_nid(pfn)))
+	    online_type == MMOP_ONLINE_MOVABLE))
 		return -EINVAL;
 
 	if (online_type == MMOP_ONLINE_KERNEL) {
@@ -1323,7 +1305,7 @@ int __ref add_memory_resource(int nid, struct resource *res, bool online)
 	}
 
 	/* call arch's memory hotadd */
-	ret = arch_add_memory(nid, start, size, true);
+	ret = arch_add_memory(nid, start, size, false);
 
 	if (ret < 0)
 		goto error;


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/1761104

Fix partial backport from bug #1747069, remove can_online_high_movable and fix
the incorrectly set boolean argument to arch_add_memory().
Reverting 4fe85d5a7c50f003fe4863a1a87f5d8cc121c75c

Signed-off-by: Gustavo Walbon <gwalbon@linux.vnet.ibm.com>